### PR TITLE
fix: Add missing use_cached_prices parameter to PortfolioService

### DIFF
--- a/src/simple_order_management_platform/services/portfolio_service.py
+++ b/src/simple_order_management_platform/services/portfolio_service.py
@@ -20,14 +20,16 @@ logger = logging.getLogger(__name__)
 class PortfolioService:
     """Service for downloading and managing portfolio positions from IBKR."""
     
-    def __init__(self, ib_provider: IBProvider):
+    def __init__(self, ib_provider: IBProvider, use_cached_prices: bool = False):
         """Initialize portfolio service.
         
         Args:
             ib_provider: Interactive Brokers provider instance
+            use_cached_prices: Whether to use cached prices for position valuation
         """
         self.ib_provider = ib_provider
         self.ib: IB = ib_provider.connector.ib
+        self.use_cached_prices = use_cached_prices
     
     def get_all_accounts(self) -> List[str]:
         """Get all managed account IDs.


### PR DESCRIPTION
🐛 Fixed Critical Bug:
- Added use_cached_prices parameter to PortfolioService.__init__()
- Default value: False (maintains backward compatibility)
- Resolves AttributeError: 'PortfolioService' object has no attribute 'use_cached_prices'

🔧 Root Cause:
- CLI code was passing use_cached_prices=True parameter
- But PortfolioService class wasn't accepting this parameter
- Position conversion methods were accessing self.use_cached_prices
- Attribute didn't exist, causing portfolio download failures

✅ Impact:
- ./download-positions command now works correctly
- ./download-positions-cached command continues to work
- All existing PortfolioService usage remains unaffected
- Cached pricing functionality fully operational

🧪 Testing:
- Verified parameter acceptance in __init__ method
- Confirmed backward compatibility with existing code
- All CLI shortcuts maintain full functionality