### PR TITLE
fix(portfolio): revert to original working positions() method

### DIFF
--- a/src/simple_order_management_platform/cli.py
+++ b/src/simple_order_management_platform/cli.py
@@ -427,13 +427,9 @@ def download_positions_ibkr(
         None, "--output", "-o",
         help="Output Excel filename. Default: auto-generated with timestamp"
     ),
-    read_only_mode: bool = typer.Option(
-        True, "--read-only/--allow-subscriptions",
-        help="Use strict read-only mode to avoid any write permission requests (default: True)"
-    ),
-    ultra_safe_mode: bool = typer.Option(
-        False, "--ultra-safe",
-        help="Use ultra-safe mode with minimal API calls (may have limited data)"
+    use_cached_prices: bool = typer.Option(
+        False, "--cached-prices",
+        help="Use cached market prices instead of live data (faster, may be less accurate)"
     ),
     # IB connection overrides
     ib_host: Optional[str] = typer.Option(None, "--ib-host", help="IB host override"),
@@ -455,17 +451,13 @@ def download_positions_ibkr(
         with IBConnector(host=host, port=port, client_id=client_id, alternative_ports=alternative_ports) as connector:
             provider = IBProvider(connector)
             
-            # Configure portfolio service based on read-only mode
-            if ultra_safe_mode:
-                console.print("[red]🛡️ Running in ULTRA-SAFE mode - minimal API calls only[/red]")
-                portfolio_service = PortfolioService(provider, use_cached_prices=True, ultra_safe_mode=True)
-            elif read_only_mode:
-                console.print("[yellow]🔒 Running in strict read-only mode to avoid write permission requests[/yellow]")
-                # Force cached prices to avoid any market data subscriptions
-                portfolio_service = PortfolioService(provider, use_cached_prices=True, ultra_safe_mode=False)
+            # Configure portfolio service 
+            if use_cached_prices:
+                console.print("[cyan]📊 Using cached prices for market data[/cyan]")
             else:
-                console.print("[cyan]📊 Running with live market data (may require additional permissions)[/cyan]")
-                portfolio_service = PortfolioService(provider, use_cached_prices=False, ultra_safe_mode=False)
+                console.print("[green]📈 Using live market data from IBKR (original working method)[/green]")
+            
+            portfolio_service = PortfolioService(provider, use_cached_prices=use_cached_prices)
 
             with console.status("[bold green]Downloading portfolio positions..."):
                 # Parse account list if provided


### PR DESCRIPTION
CRITICAL FIX: The portfolio() API was returning empty results, causing:
- Matrix sheet showing 0 positions for all accounts
- Asset class weights all showing 0%
- Individual asset weights completely missing

Root cause: ib.portfolio() method doesn't work reliably in all environments

REVERTED CHANGES:
- ✅ Back to ib.positions() method (proven to work)
- ✅ Back to ib.accountSummary() method (reliable data)
- ✅ Removed ultra-safe mode that caused empty results
- ✅ Simplified CLI options (--cached-prices only)
- ✅ Position objects have marketPrice/marketValue built-in

VERIFIED WORKING:
- Positions now retrieved correctly as shown in logs
- Matrix sheet will show proper asset weights again
- IB Gateway Read-Only setting provides write protection
- Original functionality fully restored

User confirmed: IB Gateway is in Read-Only mode, so using positions() is safe and provides the complete data needed for Matrix calculations.