### PR TITLE
fix: Remove remaining merge conflict markers causing syntax errors

### DIFF
--- a/src/simple_order_management_platform/services/portfolio_service.py
+++ b/src/simple_order_management_platform/services/portfolio_service.py
@@ -254,7 +254,6 @@ class PortfolioService:
             
             # PortfolioItem objects provide marketPrice and marketValue in account's base currency
             # This ensures accurate weight calculations across different instrument currencies
->>>>>>> 9546905 (Fix currency conversion issue and add Amt_Matrix sheet)
             
             market_price = None
             market_value = None

--- a/src/simple_order_management_platform/utils/ibkr_exporters.py
+++ b/src/simple_order_management_platform/utils/ibkr_exporters.py
@@ -499,14 +499,6 @@ class IBKRStandardExporter:
         if remaining_symbols:
             column_headers.append('Total (S$)')  # Total for asset amount section
             column_headers.extend(remaining_symbols)
-=======
-        column_headers = ['Account', 'Net Liquidation Value (S$)', 'Gross/NLV', 'Cash % (S$)', 'Total (S$)', 'Equity (S$)', 'Bond (S$)', 'Gold (S$)']
-        
-        # Add symbol codes as column headers with Total at the beginning
-        if remaining_symbols:
-            column_headers.append('Total (S$)')  # Total for asset amount section
-            column_headers.extend([f'{symbol} (S$)' for symbol in remaining_symbols])
->>>>>>> 9546905 (Fix currency conversion issue and add Amt_Matrix sheet)
         matrix_rows.append(column_headers)
         
         # Data rows: One row per account


### PR DESCRIPTION
- Removed leftover conflict markers from ibkr_exporters.py (line 502)
- Removed conflict marker from portfolio_service.py (line 257)
- Fixes SyntaxError: invalid syntax that prevented ./holdings from running

All conflict markers have been properly resolved and code is now executable.